### PR TITLE
Ignore bad UTF-8 characters.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -35,7 +35,8 @@ preprocess.for.type = function( x, nastrings ){
   
   x = as.character(x)
   x[ x %in% nastrings ] <- NA
-  x = tolower( stringr::str_trim(x) )
+  # ignore bad characters
+  x = tolower( stringr::str_trim(iconv(x, 'UTF-8', 'UTF-8//IGNORE')) )
 
   return(x)
 


### PR DESCRIPTION
Bad UTF-8 characters in the data could cause issues in totype() and atype(). This solution is to ignore the bad UTF-8 characters.