### PR TITLE
Update easyr to 0.5.11 and remove openssl and readxlsb as imports. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,18 +26,17 @@ Imports:
     glue,
     Hmisc,
     lubridate,
-    stringr,
     methods,
-    openssl,
     readxl,
-    readxlsb,
     rlang,
     rprojroot,
+    stringr,
     XML
 RoxygenNote: 7.1.1
 Suggests: 
     pdftools,
     qs,
     rstudioapi,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    readxlsb
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: easyr
 Type: Package
 Title: Helpful Functions from Oliver Wyman Actuarial Consulting
-Version: 0.5-10
+Version: 0.5-11
 Authors@R: c(
         person( "Oliver Wyman", "Actuarial Consulting", email = "rajesh.sahasrabuddhe@oliverwyman.com", role = c("aut", "cph") ),
         person( "Bryce", "Chamberlain", email = "bryce.chamberlain@oliverwyman.com", role = c("aut", "cre") ),

--- a/R/hashfiles.R
+++ b/R/hashfiles.R
@@ -61,7 +61,7 @@ hashfiles = function( x, skip.missing = FALSE, full.hash = FALSE, verbose = FALS
         }
         
         # add to the running hash.
-        hash.out = openssl::md5( cc( hash.out, jdigest ) )[1]
+        hash.out = digest::digest( cc( hash.out, jdigest ), algo = "md5", serialize = FALSE )[1]
         
         rm( jdigest )
       

--- a/R/read.any.R
+++ b/R/read.any.R
@@ -411,8 +411,7 @@ rx <- function( filename, sheet, first_column_name, nrows, verbose ){
       x <- readxlsb::read_xlsb( path = filename, sheet = sheet )
       if(isval(nrows)) x = utils::head(x, nrows) # read_xlsb does not have an nrows argument. 
     } else {
-      warning('readxlsb has not been installed. Cannot read PDF files.')
-      return(NULL)
+      stop('Error: readxlsb has not been installed. Cannot read XLSB files. Consider using an XLSM file format instead.')
     } 
   
   # Handle xlsx

--- a/R/read.any.R
+++ b/R/read.any.R
@@ -405,9 +405,14 @@ rx <- function( filename, sheet, first_column_name, nrows, verbose ){
   # Handle xlsb
   if(grepl('[.]xlsb$', filename, ignore.case = T)){
 
-    if(!isval(sheet)) sheet = 1 # read_xlsb errors out if sheet is NULL.
-    x <- readxlsb::read_xlsb( path = filename, sheet = sheet )
-    if(isval(nrows)) x = utils::head(x, nrows) # read_xlsb does not have an nrows argument. 
+    # Check if readxlsb package is installed and loaded. Returns 
+    if('readxlsb' %in% utils::installed.packages()){
+      stop('ERROR: The "readxlsb" package is not installed. Please install the package and try again.')
+    } else {
+      if(!isval(sheet)) sheet = 1 # read_xlsb errors out if sheet is NULL.
+      x <- readxlsb::read_xlsb( path = filename, sheet = sheet )
+      if(isval(nrows)) x = utils::head(x, nrows) # read_xlsb does not have an nrows argument. 
+    } 
   
   # Handle xlsx
   } else if( grepl( '[.]xlsx$', filename, ignore.case = T ) ) {

--- a/R/read.any.R
+++ b/R/read.any.R
@@ -405,13 +405,14 @@ rx <- function( filename, sheet, first_column_name, nrows, verbose ){
   # Handle xlsb
   if(grepl('[.]xlsb$', filename, ignore.case = T)){
 
-    # Check if readxlsb package is installed and loaded. Returns 
+    # Check if readxlsb package is installed and loaded. Returns NULL if not.
     if('readxlsb' %in% utils::installed.packages()){
-      stop('ERROR: The "readxlsb" package is not installed. Please install the package and try again.')
-    } else {
       if(!isval(sheet)) sheet = 1 # read_xlsb errors out if sheet is NULL.
       x <- readxlsb::read_xlsb( path = filename, sheet = sheet )
       if(isval(nrows)) x = utils::head(x, nrows) # read_xlsb does not have an nrows argument. 
+    } else {
+      warning('readxlsb has not been installed. Cannot read PDF files.')
+      return(NULL)
     } 
   
   # Handle xlsx

--- a/tests/testthat/test_read.any.R
+++ b/tests/testthat/test_read.any.R
@@ -133,22 +133,25 @@ test_that( 'times read in properly', {
 #  
 #})
 
-# test_that( 'read xlsb', {
+test_that( 'read xlsb', {
 
-#   expect_equal( 
-#     nrow(read.any( test_file( 'sample.xlsb'))),
-#     14
-#   )
+  if('readxlsb' %in% utils::installed.packages()){ 
 
-#   expect_equal( 
-#     nrow(read.any( test_file( 'sample.xlsb'), sheet = 1)),
-#     14
-#   )
+    expect_equal( 
+      nrow(read.any( test_file( 'sample.xlsb'))),
+      14
+    )
 
-#   expect_equal( 
-#     nrow(read.any( test_file( 'sample.xlsb'), sheet = 2)),
-#     14
-#   )
+    expect_equal( 
+      nrow(read.any( test_file( 'sample.xlsb'), sheet = 1)),
+      14
+    )
 
-# })
+    expect_equal( 
+      nrow(read.any( test_file( 'sample.xlsb'), sheet = 2)),
+      14
+    )
 
+  }
+
+})

--- a/tests/testthat/test_read.any.R
+++ b/tests/testthat/test_read.any.R
@@ -133,22 +133,22 @@ test_that( 'times read in properly', {
 #  
 #})
 
-test_that( 'read xlsb', {
+# test_that( 'read xlsb', {
 
-  expect_equal( 
-    nrow(read.any( test_file( 'sample.xlsb'))),
-    14
-  )
+#   expect_equal( 
+#     nrow(read.any( test_file( 'sample.xlsb'))),
+#     14
+#   )
 
-  expect_equal( 
-    nrow(read.any( test_file( 'sample.xlsb'), sheet = 1)),
-    14
-  )
+#   expect_equal( 
+#     nrow(read.any( test_file( 'sample.xlsb'), sheet = 1)),
+#     14
+#   )
 
-  expect_equal( 
-    nrow(read.any( test_file( 'sample.xlsb'), sheet = 2)),
-    14
-  )
+#   expect_equal( 
+#     nrow(read.any( test_file( 'sample.xlsb'), sheet = 2)),
+#     14
+#   )
 
-})
+# })
 


### PR DESCRIPTION
Hello Bryce,

Setting up this PR now. 

1. Have updated files such that openssl is no longer used at all. Digest, already used, was able to replicate the function that openssl was imported for.
2. Have updated files such that readxlsb is no longer an import, but rather a suggestion. This mimics how the package already treats reading in PDF files where pdftools is suggested, and if not installed, will return NULL and a warning. This is now the same for XSLB files types.
3. Tests have been updated to reflect these changes. 
4. No tests are failing through build-install-test.R. 
5. R CMD check is passing with no errors, warnings, or notes.
6. Having an issue with this step here: rhub::check(platform = "debian-gcc-devel-nold"). Requests a token via an email sent to your email since you are listed as a maintainer. 
   